### PR TITLE
UTC datetime used as lastUpdated

### DIFF
--- a/lib/nstack.dart
+++ b/lib/nstack.dart
@@ -123,7 +123,7 @@ class NStack<T> {
         // Update cache for key
         prefs.setString(nstackKey, bestFitLanguageResponse);
         // Update last_updated for next app open call
-        prefs.setString(prefsKeyLastUpdated, DateTime.now().toIso8601String());
+        prefs.setString(prefsKeyLastUpdated, DateTime.now().toUtc().toIso8601String());
       } else {
         // Using best fit language from the cache
         if (prefs.containsKey(nstackKey)) {


### PR DESCRIPTION
Flutter is yet to support the Time Zone info in the [DateFormat](https://pub.dev/documentation/intl/latest/intl/DateFormat-class.html) class 
