### PR TITLE
Add platformOverride in `NStackAppOpen`

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import 'nstack.dart';
 
 void main() {
@@ -18,17 +19,18 @@ class MainScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return NStackAppOpen(
-      platformOverride: "android",
+      platformOverride: AppOpenPlatform.android,
       child: Scaffold(
         appBar: AppBar(
           title: Text(context.localization.test.testDollarSign),
         ),
         body: Center(
-          child: MaterialButton(onPressed: () async => {
-            NStackScope.of(context).changeLanguage(Locale("de-DE"))
-          },
-            child: Text("Selected locale: ${NStackScope.of(context).nstack.activeLanguage.name}")
-            ,),
+          child: MaterialButton(
+            onPressed: () async =>
+                {NStackScope.of(context).changeLanguage(Locale("de-DE"))},
+            child: Text(
+                "Selected locale: ${NStackScope.of(context).nstack.activeLanguage.name}"),
+          ),
         ),
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,6 +18,7 @@ class MainScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return NStackAppOpen(
+      platformOverride: "android",
       child: Scaffold(
         appBar: AppBar(
           title: Text(context.localization.test.testDollarSign),

--- a/example/lib/nstack.dart
+++ b/example/lib/nstack.dart
@@ -29,7 +29,7 @@ class _DefaultSection extends SectionKeyDelegate {
 class _Test extends SectionKeyDelegate {
 	const _Test(): super('test');
 
-	String get testDollarSign => get('testDollarSign', "\$testing change back");
+	String get testDollarSign => get('testDollarSign', "\$testing again");
 	String get testSingleQuotationMark => get('testSingleQuotationMark', "\'testing\'");
 	String get testDoubleQuotationMark => get('testDoubleQuotationMark', "\"testing\"");
 	String get testMultipleLines => get('testMultipleLines', "testing\nmultiple\nlines");
@@ -43,7 +43,7 @@ final _languages = [
 ];
 
 const _bundledTranslations = {
-	'en-EN': r'''{"data":{"default":{"title":"NStack SDK Demo","test":"test"},"test":{"testDollarSign":"$testing change back","testSingleQuotationMark":"'testing'","testDoubleQuotationMark":"\"testing\"","testMultipleLines":"testing\nmultiple\nlines"}},"meta":{"language":{"id":56,"name":"English","locale":"en-EN","direction":"LRM","is_default":false,"is_best_fit":false},"platform":{"id":515,"slug":"mobile"}}}''',
+	'en-EN': r'''{"data":{"default":{"title":"NStack SDK Demo","test":"test"},"test":{"testDollarSign":"$testing again","testSingleQuotationMark":"'testing'","testDoubleQuotationMark":"\"testing\"","testMultipleLines":"testing\nmultiple\nlines"}},"meta":{"language":{"id":56,"name":"English","locale":"en-EN","direction":"LRM","is_default":false,"is_best_fit":false},"platform":{"id":515,"slug":"mobile"}}}''',
 	'de-AT': r'''{"data":{"default":{"title":"NStack SDK Demo","test":"test"},"test":{"testDollarSign":"__testDollarSign","testSingleQuotationMark":"__testSingleQuotationMark","testDoubleQuotationMark":"__testDoubleQuotationMark","testMultipleLines":"__testMultipleLines"}},"meta":{"language":{"id":7,"name":"German (Austria)","locale":"de-AT","direction":"LRM","is_default":false,"is_best_fit":false},"platform":{"id":515,"slug":"mobile"}}}''',
 };
 
@@ -90,8 +90,8 @@ class NStackState extends State<NStackWidget> {
 		await _nstack.changeLocalization(locale).whenComplete(() => setState(() {}));
 	}
 
-  Future<void> appOpen(Locale locale) async {
-    await _nstack.appOpen(locale).whenComplete(() => setState(() {}));
+  Future<void> appOpen(Locale locale, {String? platformOverride}) async {
+    await _nstack.appOpen(locale, platformOverride: platformOverride).whenComplete(() => setState(() {}));
   }
 
   @override
@@ -105,10 +105,12 @@ class NStackAppOpen extends StatefulWidget {
     Key? key,
     required this.child,
     this.onComplete,
+    this.platformOverride
   }) : super(key: key);
 
   final Widget child;
   final VoidCallback? onComplete;
+  final String? platformOverride;
 
   @override
   _NStackAppOpenState createState() => _NStackAppOpenState();
@@ -121,7 +123,7 @@ class _NStackAppOpenState extends State<NStackAppOpen> {
   Widget build(BuildContext context) {
     if (!_initializedNStack) {
       NStackScope.of(context)
-          .appOpen(Localizations.localeOf(context))
+          .appOpen(Localizations.localeOf(context), platformOverride: widget.platformOverride)
           .whenComplete(() => widget.onComplete?.call());
       _initializedNStack = true;
     }

--- a/example/lib/nstack.dart
+++ b/example/lib/nstack.dart
@@ -2,11 +2,14 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+import 'package:nstack/models/app_open_platform.dart';
 import 'package:nstack/models/language.dart';
 import 'package:nstack/models/localize_index.dart';
 import 'package:nstack/models/nstack_config.dart';
 import 'package:nstack/nstack.dart';
 import 'package:nstack/partial/section_key_delegate.dart';
+
+export 'package:nstack/models/app_open_platform.dart';
 
 // Update this file by running:
 // - `flutter pub run build_runner build`, if your package depends on Flutter
@@ -29,7 +32,7 @@ class _DefaultSection extends SectionKeyDelegate {
 class _Test extends SectionKeyDelegate {
 	const _Test(): super('test');
 
-	String get testDollarSign => get('testDollarSign', "\$testing again");
+	String get testDollarSign => get('testDollarSign', "\$testing again sdfsdf");
 	String get testSingleQuotationMark => get('testSingleQuotationMark', "\'testing\'");
 	String get testDoubleQuotationMark => get('testDoubleQuotationMark', "\"testing\"");
 	String get testMultipleLines => get('testMultipleLines', "testing\nmultiple\nlines");
@@ -43,7 +46,7 @@ final _languages = [
 ];
 
 const _bundledTranslations = {
-	'en-EN': r'''{"data":{"default":{"title":"NStack SDK Demo","test":"test"},"test":{"testDollarSign":"$testing again","testSingleQuotationMark":"'testing'","testDoubleQuotationMark":"\"testing\"","testMultipleLines":"testing\nmultiple\nlines"}},"meta":{"language":{"id":56,"name":"English","locale":"en-EN","direction":"LRM","is_default":false,"is_best_fit":false},"platform":{"id":515,"slug":"mobile"}}}''',
+	'en-EN': r'''{"data":{"default":{"title":"NStack SDK Demo","test":"test"},"test":{"testDollarSign":"$testing again sdfsdf","testSingleQuotationMark":"'testing'","testDoubleQuotationMark":"\"testing\"","testMultipleLines":"testing\nmultiple\nlines"}},"meta":{"language":{"id":56,"name":"English","locale":"en-EN","direction":"LRM","is_default":false,"is_best_fit":false},"platform":{"id":515,"slug":"mobile"}}}''',
 	'de-AT': r'''{"data":{"default":{"title":"NStack SDK Demo","test":"test"},"test":{"testDollarSign":"__testDollarSign","testSingleQuotationMark":"__testSingleQuotationMark","testDoubleQuotationMark":"__testDoubleQuotationMark","testMultipleLines":"__testMultipleLines"}},"meta":{"language":{"id":7,"name":"German (Austria)","locale":"de-AT","direction":"LRM","is_default":false,"is_best_fit":false},"platform":{"id":515,"slug":"mobile"}}}''',
 };
 
@@ -90,7 +93,7 @@ class NStackState extends State<NStackWidget> {
 		await _nstack.changeLocalization(locale).whenComplete(() => setState(() {}));
 	}
 
-  Future<void> appOpen(Locale locale, {String? platformOverride}) async {
+  Future<void> appOpen(Locale locale, {AppOpenPlatform? platformOverride}) async {
     await _nstack.appOpen(locale, platformOverride: platformOverride).whenComplete(() => setState(() {}));
   }
 
@@ -110,7 +113,7 @@ class NStackAppOpen extends StatefulWidget {
 
   final Widget child;
   final VoidCallback? onComplete;
-  final String? platformOverride;
+  final AppOpenPlatform? platformOverride;
 
   @override
   _NStackAppOpenState createState() => _NStackAppOpenState();

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -302,7 +302,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   package_config:
     dependency: transitive
     description:

--- a/lib/models/app_open_platform.dart
+++ b/lib/models/app_open_platform.dart
@@ -1,0 +1,25 @@
+/// See https://github.com/nstack-io/nstack-server/blob/master/project/Models/AppOpens/Validation/AppOpenValidator.php
+enum AppOpenPlatform {
+  ios,
+  android,
+  windows,
+  web,
+  unknown,
+}
+
+extension AppOpenPlatformExtensions on AppOpenPlatform {
+  String get slug {
+    switch (this) {
+      case AppOpenPlatform.ios:
+        return 'ios';
+      case AppOpenPlatform.android:
+        return 'android';
+      case AppOpenPlatform.windows:
+        return 'windows';
+      case AppOpenPlatform.web:
+        return 'web';
+      case AppOpenPlatform.unknown:
+        return 'unknown';
+    }
+  }
+}

--- a/lib/models/nstack_appopen_data.dart
+++ b/lib/models/nstack_appopen_data.dart
@@ -1,5 +1,7 @@
+import 'package:nstack/models/app_open_platform.dart';
+
 class NStackAppOpenData {
-  final String platform;
+  final AppOpenPlatform platform;
   final String guid;
   final String version;
   final String oldVersion;

--- a/lib/nstack.dart
+++ b/lib/nstack.dart
@@ -59,7 +59,7 @@ class NStack<T> {
     );
   }
 
-  Future<void> _setupAppOpenData() async {
+  Future<void> _setupAppOpenData(String? platformOverride) async {
     WidgetsFlutterBinding.ensureInitialized();
     final prefs = await SharedPreferences.getInstance();
     String projectVersion;
@@ -97,7 +97,7 @@ class NStack<T> {
     }
 
     _appOpenData = NStackAppOpenData(
-      platform: platform,
+      platform: platformOverride ?? platform,
       guid: guid,
       lastUpdated: lastUpdated,
       oldVersion: projectVersion,
@@ -171,14 +171,14 @@ class NStack<T> {
     }
   }
 
-  Future<AppOpenResult> appOpen(Locale locale) async {
+  Future<AppOpenResult> appOpen(Locale locale, {String? platformOverride}) async {
     try {
       if (_appOpenCalled) {
         _log("NStack.appOpen() has already been called, returning early...");
         return AppOpenResult.success;
       }
 
-      await _setupAppOpenData();
+      await _setupAppOpenData(platformOverride);
 
       // Has user selected a language in the app?
       final prefs = await SharedPreferences.getInstance();

--- a/lib/nstack.dart
+++ b/lib/nstack.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart' as Foundation;
 import 'package:flutter/widgets.dart';
 import 'package:nstack/models/app_open.dart';
+import 'package:nstack/models/app_open_platform.dart';
 import 'package:nstack/models/language.dart';
 import 'package:nstack/models/language_response.dart';
 import 'package:nstack/models/localize_index.dart';
@@ -28,7 +29,8 @@ class NStack<T> {
   late NStackAppOpenData _appOpenData;
   final bool debug;
 
-  List<Language> get availableLanguages => LocalizationRepository().availableLanguages;
+  List<Language> get availableLanguages =>
+      LocalizationRepository().availableLanguages;
 
   Language get activeLanguage => LocalizationRepository().pickedLanguage;
 
@@ -59,13 +61,13 @@ class NStack<T> {
     );
   }
 
-  Future<void> _setupAppOpenData(String? platformOverride) async {
+  Future<void> _setupAppOpenData(AppOpenPlatform? platformOverride) async {
     WidgetsFlutterBinding.ensureInitialized();
     final prefs = await SharedPreferences.getInstance();
     String projectVersion;
     String guid;
     String lastUpdated;
-    String platform;
+    AppOpenPlatform platform;
 
     projectVersion = await PackageInfo.fromPlatform()
         .then((PackageInfo info) => info.version)
@@ -85,15 +87,14 @@ class NStack<T> {
 
     if (!Foundation.kIsWeb) {
       if (Platform.isAndroid) {
-        platform = 'android';
+        platform = AppOpenPlatform.android;
       } else if (Platform.isIOS) {
-        platform = 'ios';
+        platform = AppOpenPlatform.ios;
       } else {
-        //need to update when new platforms come
-        platform = 'unknown';
+        platform = AppOpenPlatform.unknown;
       }
     } else {
-      platform = 'web';
+      platform = AppOpenPlatform.web;
     }
 
     _appOpenData = NStackAppOpenData(
@@ -171,7 +172,10 @@ class NStack<T> {
     }
   }
 
-  Future<AppOpenResult> appOpen(Locale locale, {String? platformOverride}) async {
+  Future<AppOpenResult> appOpen(
+    Locale locale, {
+    AppOpenPlatform? platformOverride,
+  }) async {
     try {
       if (_appOpenCalled) {
         _log("NStack.appOpen() has already been called, returning early...");
@@ -183,8 +187,9 @@ class NStack<T> {
       // Has user selected a language in the app?
       final prefs = await SharedPreferences.getInstance();
       var languageTag = locale.toLanguageTag();
-      if(prefs.containsKey(_prefsSelectedLocale)) {
-        languageTag = prefs.getString(_prefsSelectedLocale) ?? locale.toLanguageTag();
+      if (prefs.containsKey(_prefsSelectedLocale)) {
+        languageTag =
+            prefs.getString(_prefsSelectedLocale) ?? locale.toLanguageTag();
         _log("NStack --> User has overwritten device locale to: $languageTag");
       }
 
@@ -206,7 +211,8 @@ class NStack<T> {
       final nstackKey = 'nstack_lang_${bestFitLanguage?.language?.locale}';
 
       // Fetch from the server or use the cache?
-      if (bestFitLanguage?.shouldUpdate == true || !prefs.containsKey(nstackKey)) {
+      if (bestFitLanguage?.shouldUpdate == true ||
+          !prefs.containsKey(nstackKey)) {
         // Fetch best fit language from the server
         _log(
             'NStack --> Fetching best fit language: ${bestFitLanguage!.language!.locale}');
@@ -241,8 +247,10 @@ class NStack<T> {
           );
           // No cache, default values (this shouldn't happen, should_update should be true)
         } else {
-          _log('NStack --> WARNING: No cache found for best fit language: ${bestFitLanguage?.language?.locale}');
-          LocalizationRepository().switchBundledLocalization(bestFitLanguage!.language!.locale!);
+          _log(
+              'NStack --> WARNING: No cache found for best fit language: ${bestFitLanguage?.language?.locale}');
+          LocalizationRepository()
+              .switchBundledLocalization(bestFitLanguage!.language!.locale!);
         }
       }
 
@@ -251,7 +259,8 @@ class NStack<T> {
       return AppOpenResult.success;
     } catch (e, s) {
       _appOpenCalled = true;
-      LocalizationRepository().switchBundledLocalization(locale.toLanguageTag());
+      LocalizationRepository()
+          .switchBundledLocalization(locale.toLanguageTag());
       _log('NStack --> App Open failed because of: ${e.toString()}');
       _log(s.toString());
       return AppOpenResult.failed;

--- a/lib/src/nstack_builder.dart
+++ b/lib/src/nstack_builder.dart
@@ -262,8 +262,8 @@ class NStackState extends State<NStackWidget> {
 		await _nstack.changeLocalization(locale).whenComplete(() => setState(() {}));
 	}
 
-  Future<void> appOpen(Locale locale) async {
-    await _nstack.appOpen(locale).whenComplete(() => setState(() {}));
+  Future<void> appOpen(Locale locale, {String? platformOverride}) async {
+    await _nstack.appOpen(locale, platformOverride: platformOverride).whenComplete(() => setState(() {}));
   }
 
   @override
@@ -277,10 +277,12 @@ class NStackAppOpen extends StatefulWidget {
     Key? key,
     required this.child,
     this.onComplete,
+    this.platformOverride
   }) : super(key: key);
 
   final Widget child;
   final VoidCallback? onComplete;
+  final String? platformOverride;
 
   @override
   _NStackAppOpenState createState() => _NStackAppOpenState();
@@ -293,7 +295,7 @@ class _NStackAppOpenState extends State<NStackAppOpen> {
   Widget build(BuildContext context) {
     if (!_initializedNStack) {
       NStackScope.of(context)
-          .appOpen(Localizations.localeOf(context))
+          .appOpen(Localizations.localeOf(context), platformOverride: widget.platformOverride)
           .whenComplete(() => widget.onComplete?.call());
       _initializedNStack = true;
     }

--- a/lib/src/nstack_builder.dart
+++ b/lib/src/nstack_builder.dart
@@ -90,11 +90,14 @@ class NstackBuilder implements Builder {
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+import 'package:nstack/models/app_open_platform.dart';
 import 'package:nstack/models/language.dart';
 import 'package:nstack/models/localize_index.dart';
 import 'package:nstack/models/nstack_config.dart';
 import 'package:nstack/nstack.dart';
 import 'package:nstack/partial/section_key_delegate.dart';
+
+export 'package:nstack/models/app_open_platform.dart';
 
 // Update this file by running:
 // - `flutter pub run build_runner build`, if your package depends on Flutter
@@ -262,7 +265,7 @@ class NStackState extends State<NStackWidget> {
 		await _nstack.changeLocalization(locale).whenComplete(() => setState(() {}));
 	}
 
-  Future<void> appOpen(Locale locale, {String? platformOverride}) async {
+  Future<void> appOpen(Locale locale, {AppOpenPlatform? platformOverride}) async {
     await _nstack.appOpen(locale, platformOverride: platformOverride).whenComplete(() => setState(() {}));
   }
 
@@ -282,7 +285,7 @@ class NStackAppOpen extends StatefulWidget {
 
   final Widget child;
   final VoidCallback? onComplete;
-  final String? platformOverride;
+  final AppOpenPlatform? platformOverride;
 
   @override
   _NStackAppOpenState createState() => _NStackAppOpenState();

--- a/lib/src/nstack_repository.dart
+++ b/lib/src/nstack_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:nstack/models/app_open_platform.dart';
 import 'package:nstack/models/localize_index.dart';
 import 'package:nstack/models/nstack_appopen_data.dart';
 import 'package:nstack/models/nstack_config.dart';
@@ -29,7 +30,7 @@ class NStackRepository {
     mutableHeaders['Accept-Language'] = acceptHeader;
 
     final requestBody = <String, String>{
-      'platform': appOpenData.platform,
+      'platform': appOpenData.platform.slug,
       'guid': appOpenData.guid,
       'version': appOpenData.version,
       'old_version': appOpenData.oldVersion,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nstack
 description: Nstack plugin for Flutter.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/nstack-io/flutter-sdk
 
 environment:


### PR DESCRIPTION
In some cases Android, iOS and Flutter web will share the same platform in NStack - if the web platform is taking up by a CMS  or SPA on top of an API.

In those cases it would be useful to override the platform detected internally in NStack.