### PR TITLE
Simplified App Open and `init*()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ dependencies:
   nstack:
     git:
       url: git://github.com/nstack-io/flutter-sdk.git
-      ref: v0.4.1
+      ref: v0.5.0
 
 dev_dependencies:
   build_runner:
@@ -69,8 +69,7 @@ Now increment the `"version"` number and save (⌘s) to trigger an update.
 
 ## Example
 
-Import your `nstack.dart` file and plant your `NStackWidget` at the root of your application.\
-Use `NStackAppOpen` for submitting [AppOpen] events.
+Import your `nstack.dart` file and plant your `NStackWidget` in the builder of your application.
 
 ```dart
 import 'package:flutter/material.dart';
@@ -84,11 +83,14 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: NStackAppOpen(
-        child: Scaffold(
-          appBar: AppBar(
-            title: Text(context.localization.test.title),
-          ),
+      builder: (context, child) {
+        return NStackWidget(
+          child: child!,
+        );
+      },
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text(context.localization.test.title),
         ),
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,14 +3,17 @@ import 'package:flutter/material.dart';
 import 'nstack.dart';
 
 void main() {
-  runApp(NStackWidget(child: MyApp()));
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: MainScreen(),
+      home: NStackWidget(
+          platformOverride: AppOpenPlatform.android,
+          child: MainScreen()
+      ),
     );
   }
 }
@@ -18,19 +21,16 @@ class MyApp extends StatelessWidget {
 class MainScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return NStackAppOpen(
-      platformOverride: AppOpenPlatform.android,
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text(context.localization.test.testDollarSign),
-        ),
-        body: Center(
-          child: MaterialButton(
-            onPressed: () async =>
-                {NStackScope.of(context).changeLanguage(Locale("de-DE"))},
-            child: Text(
-                "Selected locale: ${NStackScope.of(context).nstack.activeLanguage.name}"),
-          ),
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(context.localization.test.testDollarSign),
+      ),
+      body: Center(
+        child: MaterialButton(
+          onPressed: () async =>
+              {NStackScope.of(context).changeLanguage(Locale("de-DE"))},
+          child: Text(
+              "Selected locale: ${NStackScope.of(context).nstack.activeLanguage.name}"),
         ),
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,10 +10,13 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: NStackWidget(
+      builder: (context, child) {
+        return NStackWidget(
           platformOverride: AppOpenPlatform.android,
-          child: MainScreen()
-      ),
+          child: child!,
+        );
+      },
+      home: MainScreen(),
     );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -302,7 +302,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.1"
+    version: "0.5.0"
   package_config:
     dependency: transitive
     description:

--- a/lib/nstack.dart
+++ b/lib/nstack.dart
@@ -176,7 +176,16 @@ class NStack<T> {
     }
   }
 
-  Future<String?> initClientLocale() async {
+  Future<bool> init() async {
+    try {
+      await _initClientLocale();
+      return true;
+    } catch(e) {
+      return false;
+    }
+  }
+
+  Future<String?> _initClientLocale() async {
     final prefs = await SharedPreferences.getInstance();
     if (prefs.containsKey(_prefsSelectedLocale)) {
       var languageTag = prefs.getString(_prefsSelectedLocale) ?? clientLocale?.toLanguageTag() ?? '';

--- a/lib/src/nstack_builder.dart
+++ b/lib/src/nstack_builder.dart
@@ -249,8 +249,10 @@ class NStackScope extends InheritedWidget {
 
 class NStackWidget extends StatefulWidget {
   final Widget child;
+  final AppOpenPlatform? platformOverride;
+  final VoidCallback? onComplete;
 
-  const NStackWidget({Key? key, required Widget child})
+  const NStackWidget({Key? key, required Widget child, this.platformOverride, this.onComplete})
       : child = child,
         super(key: key);
 
@@ -260,55 +262,38 @@ class NStackWidget extends StatefulWidget {
 
 class NStackState extends State<NStackWidget> {
 	final NStack<Localization> nstack = _nstack;
+  bool _initializedNStack = false;
+
+  late Future<bool> _nstackInitFuture;
 
   @override
   void initState() {
     super.initState();
-		_nstack.initClientLocale();
+		_nstackInitFuture = _nstack.init();
   }
 
 	changeLanguage(Locale locale) async {
 		await _nstack.changeLocalization(locale).whenComplete(() => setState(() {}));
 	}
 
-  Future<void> appOpen(Locale locale, {AppOpenPlatform? platformOverride}) async {
-    await _nstack.appOpen(locale, platformOverride: platformOverride).whenComplete(() => setState(() {}));
-  }
-
-  @override
-  Widget build(BuildContext context) {
-		return NStackScope(child: widget.child, state: this, nstack: this.nstack, checksum: nstack.checksum,);
-  }
-}
-
-class NStackAppOpen extends StatefulWidget {
-  const NStackAppOpen({
-    Key? key,
-    required this.child,
-    this.onComplete,
-    this.platformOverride
-  }) : super(key: key);
-
-  final Widget child;
-  final VoidCallback? onComplete;
-  final AppOpenPlatform? platformOverride;
-
-  @override
-  _NStackAppOpenState createState() => _NStackAppOpenState();
-}
-
-class _NStackAppOpenState extends State<NStackAppOpen> {
-  bool _initializedNStack = false;
-
   @override
   Widget build(BuildContext context) {
     if (!_initializedNStack) {
-      NStackScope.of(context)
+      _nstack
           .appOpen(Localizations.localeOf(context), platformOverride: widget.platformOverride)
           .whenComplete(() => widget.onComplete?.call());
       _initializedNStack = true;
     }
-    return widget.child;
+
+    return FutureBuilder(
+        future: _nstackInitFuture,
+        builder: (context, snapshot) {
+          if(snapshot.connectionState == ConnectionState.done) {
+            return NStackScope(child: widget.child, state: this, nstack: this.nstack, checksum: nstack.checksum,);
+          } else {
+            return SizedBox();
+          }
+        });
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nstack
 description: Nstack plugin for Flutter.
-version: 0.4.2
+version: 0.5.0
 homepage: https://github.com/nstack-io/flutter-sdk
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nstack
 description: Nstack plugin for Flutter.
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/nstack-io/flutter-sdk
 
 environment:


### PR DESCRIPTION
Due to a recent discovery in that `MaterialApp.router()` exposes a `builder:` method where the BuildContext has initialised Localizations etc, we can put in NStack there and "go back" to the simpler approach.

We also wrap our internal `NStackScope` widget in a `FutureBuilder` that awaits minor state loading, such as overwritten locale or other stuff further down the line.